### PR TITLE
[PKG-2344] dav1d 1.2.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ meson setup builddir          \
     -Denable_tests=false      \
     --prefix=$PREFIX          \
     --buildtype=release       \
-    --libdir=lib
+    -Dlibdir=lib
 
 meson compile -C builddir
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,13 @@
 set -ex
 
+# libdir is set to lib, otherwise on aarch64 and some others 
+# will default to lib64
+
 meson setup builddir          \
     ${MESON_ARGS}             \
     -Denable_tests=false      \
     --prefix=$PREFIX          \
     --buildtype=release       \
-    # without this, on aarch64 and some others defaults to lib64
     --libdir=lib
 
 meson compile -C builddir

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,10 @@ set -ex
 meson setup builddir          \
     ${MESON_ARGS}             \
     -Denable_tests=false      \
-    --buildtype=release
+    --prefix=$PREFIX          \
+    --buildtype=release       \
+    # without this, on aarch64 and some others defaults to lib64
+    --libdir=lib
 
 meson compile -C builddir
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - meson >=0.49
     - ninja
-    - nasm >=2.14
+    - nasm >=2.14  # [x86_64]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,9 @@ test:
 about:
   home: https://code.videolan.org/videolan/dav1d
   summary: dav1d is the fastest AV1 decoder on all platforms
+  description: dav1d is the fastest AV1 decoder on all platforms
+  dev_url: https://code.videolan.org/videolan/dav1d
+  doc_url: https://code.videolan.org/videolan/dav1d
   license: BSD-2-Clause
   license_family: BSD
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,11 @@ test:
 about:
   home: https://code.videolan.org/videolan/dav1d
   summary: dav1d is the fastest AV1 decoder on all platforms
-  description: dav1d is the fastest AV1 decoder on all platforms
+  description: |
+      dav1d is an AV1 cross-platform decoder, open-source, and focused on speed and correctness.
+      It is now battle-tested and production-ready and can be used everywhere.
   dev_url: https://code.videolan.org/videolan/dav1d
-  doc_url: https://code.videolan.org/videolan/dav1d
+  doc_url: https://videolan.videolan.me/dav1d
   license: BSD-2-Clause
   license_family: BSD
   license_file: COPYING


### PR DESCRIPTION
[PKG-2344] dav1d 1.2.1

- fork from conda-forge: https://github.com/conda-forge/dav1d-feedstock/blob/main/recipe/meta.yaml
- upstream: https://code.videolan.org/videolan/dav1d/-/tree/1.2.1
- linter
- include `nasm` for `x86_64`
- `meson` param `libdir` is set to `lib`, otherwise on `aarch64` and some others will default to `lib64`. It uses `-Dlibdir=lib` because it is already passed to `${MESON_ARGS}` for `osx-arm64` and some others and it can't be used together with `--libdir`.

[PKG-2344]: https://anaconda.atlassian.net/browse/PKG-2344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ