### PR TITLE
dav1d-1.5.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,6 @@ meson setup builddir          \
     ${MESON_ARGS}             \
     -Denable_tests=false      \
     --prefix=$PREFIX          \
-    --buildtype=release       \
     -Dlibdir=lib
 
 meson compile -C builddir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "dav1d" %}
-{% set version = "1.2.1" %}
+{% set version = "1.5.3" %}
 # library version is different from project version
 # Check 'meson.build' upstream in every release!
-{% set so_name = "6.9.0" %}
-{% set so_name_major = "6" %}
+{% set so_name = "7.0.0" %}
+{% set so_name_major = "7" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://code.videolan.org/videolan/dav1d/-/archive/{{ version }}/dav1d-{{ version }}.tar.gz
-  sha256: 2dd85860d213479672b1c708e31593446e8c2b53ff41e2ca25a2eafb718424e2
+  sha256: cbe212b02faf8c6eed5b6d55ef8a6e363aaab83f15112e960701a9c3df813686
 
 build:
   number: 0
@@ -20,9 +20,10 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - meson >=0.49
-    - ninja
+    - ninja-base
     - nasm >=2.14  # [x86_64]
 
 test:
@@ -36,8 +37,8 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\dav1d.lib exit 1               # [win]
     - test -f ${PREFIX}/include/dav1d/dav1d.h                             # [unix]
     - if not exist %PREFIX%\\Library\\include\\dav1d\\dav1d.h exit 1      # [win]
-    - test -f ${PREFIX}/lib/pkgconfig/dav1d.pc                         # [unix]
-    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\dav1d.pc exit 1  # [win]
+    - test -f ${PREFIX}/lib/pkgconfig/dav1d.pc                            # [unix]
+    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\dav1d.pc exit 1     # [win]
 
 about:
   home: https://code.videolan.org/videolan/dav1d


### PR DESCRIPTION
dav1d-1.5.3

**Destination channel:** {defaults}

### Links

jira | https://anaconda.atlassian.net/browse/PKG-12967
dev_url (recipe) | https://code.videolan.org/videolan/dav1d
conda-forge | https://github.com/conda-forge/dav1d-feedstock
Anaconda Recipes | https://github.com/AnacondaRecipes/dav1d-feedstock

[CVE-2024-1580](https://code.videolan.org/videolan/dav1d/-/blob/1.5.3/NEWS?ref_type=tags#L108)

### Explanation of changes:

- bump 1.2.1 -> 1.5.3
