### PR TITLE
dav1d rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,14 @@
 @echo on
 
 
+set "MESON_ASM_ARGS="
+if "%target_platform%"=="win-arm64" set "MESON_ASM_ARGS=-Denable_asm=false"
+
 meson setup builddir           ^
     %MESON_ARGS%               ^
     --prefix=%LIBRARY_PREFIX%  ^
     -Denable_tests=false       ^
-    -Denable_asm=false         ^
+    %MESON_ASM_ARGS%           ^
     --buildtype=release
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,7 @@ meson setup builddir           ^
     %MESON_ARGS%               ^
     --prefix=%LIBRARY_PREFIX%  ^
     -Denable_tests=false       ^
+    -Denable_asm=false         ^
     --buildtype=release
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - meson >=0.49
+    - meson >=0.49  # analint: python_build_tools_in_host
     - ninja-base
     - nasm >=2.14  # [x86_64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: cbe212b02faf8c6eed5b6d55ef8a6e363aaab83f15112e960701a9c3df813686
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage( name|lower, max_pin='x.x.x') }}
 


### PR DESCRIPTION
dav1d rebuild

**Destination channel:** defaults

### Links

- [PKG-15415](https://anaconda.atlassian.net/browse/PKG-15415) 

### Explanation of changes:

- Bump build number
- Fix lint
- Disable building asm files for win-arm64
    - Fixes `meson.build:359:12: ERROR: Program 'gas-preprocessor.pl' not found or not executable`


[PKG-15415]: https://anaconda.atlassian.net/browse/PKG-15415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ